### PR TITLE
Fix pastry case sensitivity

### DIFF
--- a/src/main/java/powerbake/address/logic/commands/AddOrderCommand.java
+++ b/src/main/java/powerbake/address/logic/commands/AddOrderCommand.java
@@ -98,16 +98,26 @@ public class AddOrderCommand extends AddCommand {
 
         for (ArrayList<String> order : unformattedOrderList) {
             // Check for valid pastry name
-            if (lastShownList.stream().noneMatch(pastry -> pastry.getName().toString().equals(order.get(0)))) {
+            if (lastShownList.stream()
+                    .noneMatch(pastry -> pastry
+                            .getName()
+                            .toString()
+                            .equals(order.get(0)))) {
                 throw new CommandException(Messages.MESSAGE_INVALID_PASTRY_DISPLAYED);
             }
-            Pastry pastry = lastShownList.stream().filter(p -> p.getName().toString().equals(order.get(0)))
+
+            Pastry pastry = lastShownList.stream()
+                    .filter(existingPastry -> existingPastry
+                            .getName()
+                            .toString()
+                            .equals(order.get(0)))
                     .findFirst().get();
 
             // Check for duplicates
             if (uniquePastryNames.contains(pastry.getName().toString())) {
                 throw new CommandException(Messages.MESSAGE_REPEATED_PASTRY_IN_ORDER);
             }
+            // Create and add order Object
             int quantity = Integer.parseInt(order.get(1));
             OrderItem newOrder = new OrderItem(pastry, quantity);
             orderItems.add(newOrder);

--- a/src/main/java/powerbake/address/logic/parser/AddOrderCommandParser.java
+++ b/src/main/java/powerbake/address/logic/parser/AddOrderCommandParser.java
@@ -24,7 +24,8 @@ public class AddOrderCommandParser implements Parser<AddOrderCommand> {
     public AddOrderCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_ORDER, PREFIX_PASTRY_NAME);
-        // check
+
+        // check if order and pastry name are present in the command
         if (!arePrefixesPresent(argMultimap, PREFIX_ORDER, PREFIX_PASTRY_NAME)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddOrderCommand.MESSAGE_USAGE));

--- a/src/main/java/powerbake/address/model/AddressBook.java
+++ b/src/main/java/powerbake/address/model/AddressBook.java
@@ -3,6 +3,7 @@ package powerbake.address.model;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import javafx.collections.ObservableList;
 import powerbake.address.commons.util.ToStringBuilder;
@@ -127,7 +128,15 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public boolean hasPastry(Pastry pastry) {
         requireNonNull(pastry);
-        return pastries.contains(pastry);
+        Stream<Pastry> duplicatePastry = pastries.asUnmodifiableObservableList()
+                .stream()
+                .filter(existing_pastry ->
+                        pastry.getName()
+                                .toString()
+                                .equalsIgnoreCase(existing_pastry
+                                        .getName()
+                                        .toString()));
+        return duplicatePastry.findAny().isPresent();
     }
 
     /**


### PR DESCRIPTION
Fixes #140 

Now duplicate pastry with same name are not allow. Eg. Croissant vs crOiSSant 